### PR TITLE
changed return type of QDP::TimeSliceIO::getTimeSlice() from void to int

### DIFF
--- a/include/qdp_disk_map_slice.h
+++ b/include/qdp_disk_map_slice.h
@@ -32,7 +32,7 @@ namespace QDP
     ~TimeSliceIO() {}
 
     void setTimeSlice(int time_slice);
-    void getTimeSlice() const {return current_time;}
+    int getTimeSlice() const {return current_time;}
     T&   getObject() const {return data;}
 
     void binaryRead(BinaryReader& bin);


### PR DESCRIPTION
'include/qdp_disk_map_slice.h' had the incorrect return type for QDP::TimeSliceIO::getTimeSlice() and code including this header wouldn't compile.