### PR TITLE
Replaced the gitmodule addresses to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "other_libs/libintrin"]
 	path = other_libs/libintrin
-	url = git@github.com:usqcd-software/libintrin.git
+	url = https://github.com/usqcd-software/libintrin.git
 [submodule "other_libs/xpath_reader"]
 	path = other_libs/xpath_reader
-	url = git@github.com:usqcd-software/xpath_reader.git
+	url = https://github.com/usqcd-software/xpath_reader.git
 [submodule "other_libs/qio"]
 	path = other_libs/qio
-	url = git@github.com:usqcd-software/qio.git
+	url = https://github.com/usqcd-software/qio.git
 [submodule "other_libs/filedb"]
 	path = other_libs/filedb
-	url = git@github.com:usqcd-software/filedb.git
+	url = https://github.com/usqcd-software/filedb.git


### PR DESCRIPTION
I believe that the module paths should be updated from using SSH to use the HTTPS as this has been the github standard for quite a while (see my Issue #8).

I recently tried installing the library on JUQUEEN. I got a:

`Permission denied (publickey)`

error when I did

`git submodule update --init --recursive`

to pull down the submodules. Updating the gitmodules paths fixes this issue as github has set up the HTTPS protocol for pulling and cloning while SSH is intended for write-access, hence the permission denied.