### PR TITLE
Guarded #pragma openmp with #ifdef _OPENMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,8 @@ option(QDP_USE_SSE3 "Enable SSE3 Code" OFF)
 # HDF5 from Thorsten
 option(QDP_USE_HDF5 "Enable HDF5 Code" OFF)
 
+# OpenMP
+option(QDP_USE_OPENMP "Use OpenMP" OFF)
 # Deprecate 3DNow option
 # Deprecate BG/L option
 # Deprecate BG/Q Thread binding option
@@ -164,9 +166,10 @@ set(QDP_AC_ALIGNMENT_SIZE ${QDP_ALIGNMENT_SIZE})
 message( STATUS "QDP++: Setting alignment size to ${QDP_ALIGNMENT_SIZE}")
  
 # OpenMP Support hardwired now
-find_package(OpenMP REQUIRED)
-find_package(Threads REQUIRED)
-set(QDP_USE_OMP_THREADS "1")
+if( QDP_USE_OPENMP )
+  find_package(OpenMP REQUIRED)
+  find_package(Threads REQUIRED)
+endif()
 
 # If we are parallel we need QMP
 if ( QDP_ARCH_PARSCALAR  OR  QDP_ARCH_PARSCALARVEC )

--- a/QDPXXConfig.cmake.in
+++ b/QDPXXConfig.cmake.in
@@ -72,12 +72,9 @@ if(@QDP_USE_HDF5@)
   find_dependency(HDF5 REQUIRED)
 endif()
 
-# OpenMP is always a dependency now
-if( NOT OpenMP_FOUND )
+set(QDP_USE_OPENMP @QDP_USE_OPENMP@)
+if( QDP_USE_OPENMP )
   find_dependency(OpenMP REQUIRED)
-endif()
-
-if(NOT Threads_FOUND )
   find_dependency(Threads REQUIRED)
 endif()
 

--- a/examples/unittest.h
+++ b/examples/unittest.h
@@ -32,6 +32,7 @@ class TestCase {
 private:
 public:
   virtual void run(void) = 0;
+  virtual ~TestCase() = default;
 };
 
 // A test fixture - that does extra set up before and after the test

--- a/include/qdp_dispatch.h
+++ b/include/qdp_dispatch.h
@@ -29,8 +29,9 @@ namespace QDP {
 template<class Arg>
 void dispatch_to_threads(int numSiteTable, Arg a, void (*func)(int,int,int, Arg*)){
    
-
+#ifdef _OPENMP
 #pragma omp parallel shared(numSiteTable, a)
+#endif
     {
      
       int threads_num = omp_get_num_threads();

--- a/include/qdp_io.h
+++ b/include/qdp_io.h
@@ -135,7 +135,7 @@ namespace QDP
         
   protected:
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
   private:
     std::istringstream f;
@@ -184,7 +184,7 @@ namespace QDP
 
   protected:
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
   private:
     std::ifstream f;
@@ -290,7 +290,7 @@ namespace QDP
     void open(const std::string& s);
 
     //! Flushes the buffer
-    void flush() {}
+    void flush() override {}
 
     //! Return entire buffer as a string
     std::string str() const;
@@ -300,7 +300,7 @@ namespace QDP
         
   protected:
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
   private:
     std::ostringstream f;
@@ -347,11 +347,11 @@ namespace QDP
     void close();
 
     //! Flushes the buffer
-    void flush();
+    void flush() override;
 
   protected:
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream()  override {return f;}
 
   private:
     std::ofstream f;
@@ -926,10 +926,10 @@ namespace QDP
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
   private:
     //! Checksum
@@ -981,10 +981,10 @@ namespace QDP
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
   private:
     //! Checksum
@@ -1221,10 +1221,10 @@ namespace QDP
     writePrimitive(const T& output);
 
     //! Get the current checksum to modify
-    virtual QDPUtil::n_uint32_t& internalChecksum() = 0;
+    virtual QDPUtil::n_uint32_t& internalChecksum() override = 0;
   
     //! Get the internal output stream
-    virtual std::ostream& getOstream() = 0;
+    virtual std::ostream& getOstream() override  = 0;
   };
 
 
@@ -1517,17 +1517,17 @@ namespace QDP
     std::string strPrimaryNode() const;
         
     //! Flushes the buffer
-    void flush() {}
+    void flush() override {}
 
     //! Clear the buffer
     void clear();
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
   private:
     //! Checksum
@@ -1568,17 +1568,17 @@ namespace QDP
     std::string strPrimaryNode() const;
         
     //! Flushes the buffer
-    void flush() {}
+    void flush() override {}
 
     //! Clear the buffer
     void clear();
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
   private:
     //! Checksum
@@ -1630,14 +1630,14 @@ namespace QDP
     void close();
 
     //! Flushes the buffer
-    void flush();
+    void flush() override;
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
   private:
     //! Checksum
@@ -1748,23 +1748,23 @@ namespace QDP
     std::string strPrimaryNode() const;
         
     //! Flushes the buffer
-    void flush() {}
+    void flush() override {}
 
     //! Clear the buffer
     void clear();
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
     //! Get the internal inpu/output stream
-    std::iostream& getIOstream() {return f;}
+    std::iostream& getIOstream() override {return f;}
 
   private:
     //! Checksum
@@ -1815,20 +1815,20 @@ namespace QDP
     void close();
 
     //! Flushes the buffer
-    void flush();
+    void flush() override;
 
   protected:
     //! Get the current checksum to modify
-    QDPUtil::n_uint32_t& internalChecksum() {return checksum;}
+    QDPUtil::n_uint32_t& internalChecksum() override {return checksum;}
   
     //! Get the internal input stream
-    std::istream& getIstream() {return f;}
+    std::istream& getIstream() override {return f;}
 
     //! Get the internal output stream
-    std::ostream& getOstream() {return f;}
+    std::ostream& getOstream() override {return f;}
 
     //! Get the internal inpu/output stream
-    std::iostream& getIOstream() {return f;}
+    std::iostream& getIOstream() override {return f;}
 
   private:
     //! Checksum

--- a/include/qdp_map_obj_disk.h
+++ b/include/qdp_map_obj_disk.h
@@ -10,6 +10,7 @@
 #include "qdp_map_obj.h"
 #include <limits>
 #include <unordered_map>
+#include <array>
 
 namespace QDP
 {

--- a/include/qdp_outer.h
+++ b/include/qdp_outer.h
@@ -418,7 +418,9 @@ private:
 
 #if 0
       // Nuke touch for now
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
         for(int j=0; j < NSites; ++j) {
              *((char *)&F[j])=0;
         }

--- a/include/qdp_parscalar_specific.h
+++ b/include/qdp_parscalar_specific.h
@@ -1100,7 +1100,7 @@ norm2(const multi1d< OLattice<T> >& s1, const Subset& s)
 		{
 			typename UnaryReturn<OLattice<T>, FnNorm2>::Type_t	dthread;
 			zero_rep(dthread.elem());
-#ifedef _OPENMP
+#ifdef _OPENMP
 			#pragma omp for
 #endif
 			for(int j=0; j < nodeSites; ++j)

--- a/include/scalarsite_generic/generic_blas_local_sumsq.h
+++ b/include/scalarsite_generic/generic_blas_local_sumsq.h
@@ -26,7 +26,9 @@ void local_sumsq(DOUBLE *Out, REAL  *In, int n_3vec)
   result = 0;
 
   if( n_3vec > 0 ) { 
+#ifdef _OPENMP
 #pragma omp parallel for reduction(+:result) private(i1)
+#endif
     for(counter=0; counter < len; counter++) {
       i1 = (double)In[counter];
       result += i1*i1;

--- a/include/scalarsite_generic/generic_blas_local_vcdot.h
+++ b/include/scalarsite_generic/generic_blas_local_vcdot.h
@@ -33,8 +33,9 @@ void l_vcdot(DOUBLE *Out_re, DOUBLE *Out_im, REAL *V1, REAL *V2, int n_3vec)
   if( n_3vec > 0 )  {
 
     int len = 24*n_3vec;	// 12*(re,im)
-    
+#ifdef _OPENMP   
 #pragma omp parallel for reduction(+:result_re,result_im) private(v1_r,v1_i,v2_r,v2_i)
+#endif
     for(counter=0; counter < len; counter+=2)  {
       v1_r = (DOUBLE)V1[counter];
       v1_i = (DOUBLE)V1[counter+1];

--- a/include/scalarsite_generic/generic_blas_local_vcdot_real.h
+++ b/include/scalarsite_generic/generic_blas_local_vcdot_real.h
@@ -32,8 +32,9 @@ void l_vcdot_real(DOUBLE *Out, REAL *V1, REAL *V2, int n_3vec)
   if( n_3vec > 0 )
   { 
     int len = 24*n_3vec;	// 12*(re,im)
-
+#ifdef _OPENMP
 #pragma omp parallel for reduction(+:result) private(v1_r,v1_i,v2_r,v2_i)
+#endif
     for(counter=0; counter < len; counter+=2)
     {
 	    v1_r = (DOUBLE)V1[counter];

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -140,7 +140,9 @@ if( QDP_USE_HDF5 )
 	target_link_libraries( qdp PUBLIC hdf5::hdf5 )
 endif()
 
-target_link_libraries( qdp PUBLIC OpenMP::OpenMP_CXX )
+if( QDP_USE_OPENMP )
+  target_link_libraries( qdp PUBLIC OpenMP::OpenMP_CXX )
+endif()
 
 if( QDP_SANITIZER_OPTS )
   target_compile_options(qdp PUBLIC ${QDP_SANITIZER_OPTS})

--- a/lib/qdp_bgq_threadbind.cc
+++ b/lib/qdp_bgq_threadbind.cc
@@ -18,7 +18,9 @@ namespace QDP
 #ifdef QDP_USE_OMP_THREADS
   void setThreadAffinity(int nCores, int threadsPerCore)
   {
-    #pragma omp parallel 
+#ifdef _OPENMP
+    #pragma omp parallel
+#endif
     {
 
       // Get the OpenMP thread number
@@ -57,7 +59,9 @@ namespace QDP
 
     uint32_t cids[64], htids[64];
 
+#ifdef _OPENMP
 #pragma omp parallel
+#endif
     {
       htids[omp_get_thread_num()] = Kernel_ProcessorThreadID();
       cids[omp_get_thread_num()] = Kernel_ProcessorCoreID();

--- a/lib/qdp_parscalar_specific.cc
+++ b/lib/qdp_parscalar_specific.cc
@@ -46,7 +46,9 @@ namespace QDP {
        Loop works out forward and backward neighbours and writes
        one value per value of linear. So no write conflicts */
 
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
     for(int linear=0; linear < nodeSites; ++linear)
     {
       // Get the true lattice coord of this linear site index

--- a/lib/qdp_scalar_layout.cc
+++ b/lib/qdp_scalar_layout.cc
@@ -239,7 +239,9 @@ namespace QDP
 
 
       // Sanity check - check the layout functions make sense
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
       for(int i=0; i < _layout.vol; ++i) 
       {
 	int j = Layout::linearSiteIndex(Layout::siteCoords(Layout::nodeNumber(),i));

--- a/lib/qdp_scalar_specific.cc
+++ b/lib/qdp_scalar_specific.cc
@@ -31,7 +31,9 @@ void Map::make(const MapFunc& func)
   // const multi1d<int>& nrow = Layout::lattSize();
 
   // Loop over the sites on this node
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
   for(int linear=0; linear < Layout::vol(); ++linear)
   {
     // Get the true lattice coord of this linear site index

--- a/lib/qdp_scalarsite_specific.cc
+++ b/lib/qdp_scalarsite_specific.cc
@@ -27,7 +27,9 @@ namespace Layout
 
     /* This pragma is from Jacques... Should be OK, since each i is independent
      * no danger of concurrent writes */
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
     for(int i=0; i < nodeSites; ++i) 
     {
       Integer cc = Layout::siteCoords(nodeNumber,i)[mu];
@@ -75,7 +77,9 @@ void Set::make(const SetFunc& fun)
   // Loop over linear sites determining their color
   /* This OMP pragma added by Jacques. Should be OK since in the end 
      each value of linear is independent */
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
   for(int linear=0; linear < nodeSites; ++linear)
   {
     multi1d<int> coord = Layout::siteCoords(nodeNumber, linear);
@@ -113,8 +117,9 @@ void Set::make(const SetFunc& fun)
    * Should be OK because each subset is independent, 
    * tho the number of subsets may be small... so scope for improvement
    * from threading may be limited */
-
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
   for(int cb=0; cb < nsubset_indices; ++cb)
   {
     // Always construct the sitetables. 


### PR DESCRIPTION
I guarded a bunch of `#pragma omp ...` directrives with `#ifdef _OPENMP` guards, and messed with CMake  to allow building either with or without OpenMP.

This enabled me to build with Apple Clang (which seems to not support OpenMP), and revealed a couple of other complaints about some virtual function overrides not being marked `override` as well as a place where I needed to include a header.
These should all be fixed. 

Can you please review and merge ?